### PR TITLE
RDKB-58602: MultiVAP related changes

### DIFF
--- a/src/wifi_hal.c
+++ b/src/wifi_hal.c
@@ -130,6 +130,10 @@ INT wifi_hal_getHalCapability(wifi_hal_capability_t *hal)
     bool is_band_found = false;
     unsigned int radio_band = 0;
     char output[256] = {0};
+    mac_addr_str_t al_ctrl_mac;
+    char ifname[100] = {0};
+    int ret = 0, colocated_mode;
+    bool interface_found = false;
     NULL_PTR_ASSERT(hal);
 
     hal->version.major = WIFI_HAL_MAJOR;
@@ -193,7 +197,6 @@ INT wifi_hal_getHalCapability(wifi_hal_capability_t *hal)
         output[strlen(output) - 1] = '\0';
     }
     to_mac_bytes(output,hal->wifi_prop.al_1905_mac);
-    wifi_hal_error_print("serialNo=%s, ModelName=%s,sw_version=%s, manufacturer=%s eth0=%s Line=%d\n",hal->wifi_prop.serialNo,hal->wifi_prop.manufacturerModel,hal->wifi_prop.software_version,hal->wifi_prop.manufacturer,output,__LINE__);
 #elif (defined (_PLATFORM_RASPBERRYPI_))
    /* Copy device manufacturer,model,serial no and software version to here */
     memset(output, '\0', sizeof(output));
@@ -232,8 +235,59 @@ INT wifi_hal_getHalCapability(wifi_hal_capability_t *hal)
         output[strlen(output) - 1] = '\0';
     }
     to_mac_bytes(output,hal->wifi_prop.al_1905_mac);
-    wifi_hal_error_print("serialNo=%s, ModelName=%s,sw_version=%s, manufacturer=%s eth0=%s Line=%d\n",hal->wifi_prop.serialNo,hal->wifi_prop.manufacturerModel,hal->wifi_prop.software_version,hal->wifi_prop.manufacturer,output,__LINE__);
 #endif
+
+    /* Read the al_mac address from EM_CFG_FILE */
+    ret = json_parse_string(EM_CFG_FILE, "Al_MAC_ADDR", al_ctrl_mac, sizeof(al_ctrl_mac));
+    if (ret == 0) {
+        to_mac_bytes(al_ctrl_mac, hal->wifi_prop.al_1905_mac);
+        wifi_hal_dbg_print("%s:%d al_mac %s read from json file:%s.\n", __func__, __LINE__,
+            al_ctrl_mac, EM_CFG_FILE);
+    } else {
+        wifi_hal_error_print("%s:%d: Unable to read al_mac from json file:%s, error:%d\n", __func__,
+            __LINE__, EM_CFG_FILE, ret);
+        memset(hal->wifi_prop.al_1905_mac, 0, sizeof(hal->wifi_prop.al_1905_mac));
+        hal->wifi_prop.colocated_mode = -1;
+    }
+
+    /* Read the collocated mode from EM_CFG_FILE*/
+    ret = json_parse_integer(EM_CFG_FILE, "Colocated_Mode", &colocated_mode);
+    if (ret == 0) {
+        hal->wifi_prop.colocated_mode = colocated_mode;
+        interface_found = get_ifname_from_mac((mac_address_t *)hal->wifi_prop.al_1905_mac, ifname);
+        /* Based on the value of colocated_mode and the interface obtained from almac_address
+           Configure the vap_name appropriately */
+        if (interface_found == true) {
+            if (strncmp(ifname, "eth", strlen("eth")) != 0 &&
+                strncmp(ifname, "lo", strlen("lo")) != 0) {
+                /* interface is not an ethernet and not an loopback interface */
+                if (configure_vap_name_basedon_colocated_mode(ifname,
+                        hal->wifi_prop.colocated_mode) != 0) {
+                    wifi_hal_error_print(
+                        "%s:%d Error configuring vapname for interface:%s, colocated_mode:%d",
+                        __func__, __LINE__, ifname, hal->wifi_prop.colocated_mode);
+                }
+            } else {
+                /* almac_address is either ethernet or loopback, nothing to be done*/
+            }
+        } else {
+            /* al_mac address configured is incorrect, reset the al_1905_mac to 0*/
+            wifi_hal_error_print("%s:%d: No interface found for al_mac address:%s\n", __func__,
+                __LINE__, to_mac_str(hal->wifi_prop.al_1905_mac, al_ctrl_mac));
+            memset(hal->wifi_prop.al_1905_mac, 0, sizeof(hal->wifi_prop.al_1905_mac));
+            hal->wifi_prop.colocated_mode = -1;
+        }
+    } else {
+        wifi_hal_error_print("%s:%d: Unable to read colocated_mode from json file:%s, error:%d\n",
+            __func__, __LINE__, EM_CFG_FILE, ret);
+        hal->wifi_prop.colocated_mode = -1;
+    }
+
+    wifi_hal_info_print("%s:%d: serialNo=%s, ModelName=%s,sw_version=%s, manufacturer=%s "
+                        "al_mac_addr=%s colocated_mode:%d\n",
+        __func__, __LINE__, hal->wifi_prop.serialNo, hal->wifi_prop.manufacturerModel,
+        hal->wifi_prop.software_version, hal->wifi_prop.manufacturer,
+        to_mac_str(hal->wifi_prop.al_1905_mac, al_ctrl_mac), hal->wifi_prop.colocated_mode);
 
     for (i = 0; i < hal->wifi_prop.numRadios; i++) {
         radio_band = 0;
@@ -395,10 +449,11 @@ INT wifi_hal_init()
         interface = hash_map_get_first(radio->interface_map);
 
         while (interface != NULL) {
-            update_hostap_data(interface);
-            update_hostap_iface(interface);
-            update_hostap_iface_flags(interface);
-            init_hostap_hw_features(interface);
+            if (update_hostap_data(interface) == RETURN_OK) {
+                update_hostap_iface(interface);
+                update_hostap_iface_flags(interface);
+                init_hostap_hw_features(interface);
+            }
             interface = hash_map_get_next(radio->interface_map, interface);
         }
     }
@@ -683,7 +738,13 @@ INT wifi_hal_setRadioOperatingParameters(wifi_radio_index_t index, wifi_radio_op
                     interface->vap_info.u.bss_info.enabled, radio->configured,
                     radio->oper_param.enable);
                 if (radio->oper_param.enable && interface->vap_info.u.bss_info.enabled) {
-                    nl80211_interface_enable(interface->name, true);
+                    if (nl80211_interface_enable(interface->name, true) != 0) {
+                        ret = nl80211_retry_interface_enable(interface, true);
+                        if (ret != 0) {
+                            wifi_hal_error_print("%s:%d: Retry of interface enable failed:%d\n",
+                                __func__, __LINE__, ret);
+                        }
+                    }
                     if (update_hostap_interface_params(interface) != RETURN_OK) {
                         return RETURN_ERR;
                     }
@@ -1155,6 +1216,7 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
     platform_create_vap_t set_vap_params_fn;
     unsigned int i;
     char msg[2048];
+    int ret = 0;
 #ifdef NL80211_ACL
     int set_acl = 0;
 #else
@@ -1278,7 +1340,13 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
         if (radio->configured && radio->oper_param.enable) {
             wifi_hal_info_print("%s:%d: interface:%s set up\n", __func__, __LINE__,
                 interface->name);
-            nl80211_interface_enable(interface->name, true);
+            if (nl80211_interface_enable(interface->name, true) != 0) {
+                ret = nl80211_retry_interface_enable(interface, true);
+                if (ret != 0) {
+                    wifi_hal_error_print("%s:%d: Retry of interface enable failed:%d\n", __func__,
+                        __LINE__, ret);
+                }
+            }
         }
 
         if (vap->vap_mode == wifi_vap_mode_ap) {
@@ -1446,9 +1514,9 @@ INT wifi_hal_createVAP(wifi_radio_index_t index, wifi_vap_info_map_t *map)
                     __LINE__, interface->name);
                 wifi_drv_set_operstate(interface, 1);
             } else {
-                wifi_hal_info_print("%s:%d: interface:%s set down\n", __func__, __LINE__,
+                wifi_hal_info_print("%s:%d: interface:%s set up\n", __func__, __LINE__,
                     interface->name);
-                nl80211_interface_enable(interface->name, false);
+                nl80211_interface_enable(interface->name, true);
             }
 #endif
         }

--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -338,6 +338,12 @@ int update_hostap_data(wifi_interface_info_t *interface)
 
     vap = &interface->vap_info;
 
+    if (vap->vap_mode != wifi_vap_mode_ap || is_wifi_hal_vap_mesh_sta(vap->vap_index)) {
+        wifi_hal_error_print("%s:%d: Not an AP based VAP. Returning error\n", __func__,
+            __LINE__);
+        return RETURN_ERR;
+    }
+
     radio = get_radio_by_rdk_index(vap->radio_index);
     iconf = &radio->iconf;
 
@@ -2509,8 +2515,8 @@ void update_wpa_sm_params(wifi_interface_info_t *interface)
             wpa_sm_set_param(sm, WPA_PARAM_KEY_MGMT, key_mgmt);
         }
 
-        wifi_hal_dbg_print("update_wpa_sm_params%x %x %x\n", data.group_cipher, data.pairwise_cipher,
-            key_mgmt);
+        wifi_hal_dbg_print("%s:%d:%x %x %x\n", __func__, __LINE__, data.group_cipher,
+            data.pairwise_cipher, key_mgmt);
     } else {
         if (sec->mode == wifi_security_mode_none) {
             wpa_sm_set_param(sm, WPA_PARAM_KEY_MGMT, WPA_KEY_MGMT_NONE);

--- a/src/wifi_hal_nl80211_events.c
+++ b/src/wifi_hal_nl80211_events.c
@@ -571,7 +571,7 @@ static void nl80211_connect_event(wifi_interface_info_t *interface, struct nlatt
     }
 
     if (status != WLAN_STATUS_SUCCESS) {
-        wifi_hal_error_print("%s:%d: status code unsuccessful, returning\n", __func__, __LINE__);
+        wifi_hal_error_print("%s:%d: status code %d unsuccessful, returning\n", __func__, __LINE__, status);
         send_sta_connection_status_to_cb(backhaul->bssid, interface->vap_info.vap_index, wifi_connection_status_ap_not_found);
         return;    
     }

--- a/src/wifi_hal_nl80211_utils.c
+++ b/src/wifi_hal_nl80211_utils.c
@@ -4140,4 +4140,60 @@ void init_interface_map(void)
             l_radio_interface_map[i].radio_name, l_radio_interface_map[i].interface_name);
     }
 }
+
+void concat_band_to_vap_name(wifi_vap_name_t vap_name, unsigned int rdk_radio_index)
+{
+    switch (rdk_radio_index) {
+    case 0:
+        strncat((char *)vap_name, "2g", strlen("2g") + 1);
+        break;
+    case 1:
+        strncat((char *)vap_name, "5g", strlen("5g") + 1);
+        break;
+    case 2:
+        strncat((char *)vap_name, "6g", strlen("6g") + 1);
+        break;
+    default:
+        wifi_hal_error_print("%s:%d: Invalid rdk_radio_index:%d for vap_name:%s\n", __func__,
+            __LINE__, rdk_radio_index, vap_name);
+    }
+}
+
+int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode)
+{
+    unsigned int index = 0;
+    wifi_interface_info_t *interface = NULL;
+    for (index = 0; index < get_sizeof_interfaces_index_map(); index++) {
+        if (strncmp(interface_index_map[index].interface_name, ifname, strlen(ifname)) == 0) {
+            switch (colocated_mode) {
+            case 0:
+                strcpy((char *)interface_index_map[index].vap_name, "mesh_sta");
+                break;
+            case 1:
+                strcpy((char *)interface_index_map[index].vap_name, "mesh_backhaul");
+                break;
+            default:
+                /* Error case */
+                wifi_hal_error_print("%s:%d: Invalid colocated_mode:%d for ifname:%s\n", __func__,
+                    __LINE__, colocated_mode, ifname);
+                return -1;
+            }
+            concat_band_to_vap_name((char *)interface_index_map[index].vap_name,
+                interface_index_map[index].rdk_radio_index);
+            wifi_hal_dbg_print("%s:%d: vap_name:%s configured for ifname:%s vap_index:%d\n",
+                __func__, __LINE__, interface_index_map[index].vap_name, ifname,
+                interface_index_map[index].index);
+            if (colocated_mode == 0) {
+                interface = get_interface_by_vap_index(interface_index_map[index].index);
+                if (interface != NULL && interface->vap_info.vap_mode == wifi_vap_mode_ap) {
+                    memset(&interface->u, 0, sizeof(interface->u));
+                }
+            }
+            return 0;
+        }
+    }
+    wifi_hal_error_print("%s:%d: Interface:%s not present in interface_index_map\n", __func__,
+        __LINE__, ifname);
+    return -1;
+}
 #endif /* CONFIG_WIFI_EMULATOR */

--- a/src/wifi_hal_priv.h
+++ b/src/wifi_hal_priv.h
@@ -102,6 +102,8 @@ extern "C" {
     #define HOSTAPD_VERSION 209
 #endif
 
+#define EM_CFG_FILE "/nvram/EasymeshCfg.json"
+
 #ifdef CONFIG_WIFI_EMULATOR
 #define MAX_NUM_SIMULATED_CLIENT (MAX_NUM_RADIOS*100)
 #endif
@@ -850,6 +852,7 @@ int     nl80211_create_bridge(const char *if_name, const char *br_name);
 int     nl80211_remove_from_bridge(const char *if_name);
 int     nl80211_update_interface(wifi_interface_info_t *interface);
 int     nl80211_interface_enable(const char *ifname, bool enable);
+int     nl80211_retry_interface_enable(wifi_interface_info_t *interface, bool enable);
 void    nl80211_steering_event(UINT steeringgroupIndex, wifi_steering_event_t *event);
 int     nl80211_connect_sta(wifi_interface_info_t *interface);
 #if defined(TCXB7_PORT) || defined(TCXB8_PORT) || defined(XB10_PORT)
@@ -1062,6 +1065,10 @@ time_t get_boot_time_in_sec(void);
 int get_total_num_of_vaps(void);
 int wifi_setQamPlus(void *priv);
 int wifi_setApRetrylimit(void *priv);
+int configure_vap_name_basedon_colocated_mode(char *ifname, int colocated_mode);
+int json_parse_string(const char* file_name, const char *item_name, char *val, size_t len);
+int json_parse_integer(const char* file_name, const char *item_name, int *val);
+bool get_ifname_from_mac(const mac_address_t *mac, char *ifname);
 
 #ifdef CONFIG_IEEE80211BE
 int wifi_drv_set_ap_mlo(struct nl_msg *msg, void *priv, struct wpa_driver_ap_params *params);


### PR DESCRIPTION
Reason for change: Changes in wifi-hal to support MultiVAP configuration. 1) Change in platform_pi to read backhaul sta configuration 2) Change in other files to support backhaul sta connection in EM mode. 3) Change to read and update almac_address and colocated mode from EasymeshCfg.json to OneWifi.
4) Change to retry enabling secondary interface when it fails for first time by bringing down the primary interface, required for Canakit adapter