### PR TITLE
RDKBWIFI-24: Add vendor_ies to beacons/probes on hostapd_init_bss (#69)

### DIFF
--- a/src/wifi_hal_hostapd.c
+++ b/src/wifi_hal_hostapd.c
@@ -141,7 +141,7 @@ void set_interface_vendor_ies(wifi_interface_info_t* interface) {
         if (platform_get_vendor_oui_fn(vendor_oui, sizeof(vendor_oui)) == 0) {
             wifi_hal_dbg_print("%s:%d: vendor_oui = %s \n", __func__, __LINE__,vendor_oui);
             
-            if (elems = wpabuf_parse_bin(vendor_oui)) {
+            if ((elems = wpabuf_parse_bin(vendor_oui)) != NULL) {
                 conf->vendor_elements = elems;
             }
         }


### PR DESCRIPTION
Reason for change: To fix build error while building Comcast image
Risks: Low
Priority: P0

Testing Procedure: Modify `bss_info.vendor_elements` with valid elements before calling
    `createVAP` "somewhere" and verify with monitor mode that the VAP beacon
    and probe responses contain those vendor_elements.

Signed-off-by: gsathish86@gmail.com